### PR TITLE
ReadProcessMemory or WriteProcessMemory fix

### DIFF
--- a/MGS2-MC/GUI.cs
+++ b/MGS2-MC/GUI.cs
@@ -65,7 +65,7 @@ namespace MGS2_MC
                                 StaticGuiReference.weaponListBox.SelectedIndex = LastSelectedWeaponIndex == -1 ? 0 : LastSelectedWeaponIndex;
                                 break;
                             default:
-                                MessageBox.Show("This tab isn't yet have controller support, please use mouse & keyboard for this tab :)");
+                                MessageBox.Show(@"This tab isn't yet have controller support, please use mouse & keyboard for this tab :)");
                                 CurrentlySelectedObject = StaticGuiReference.stringsListBox.Name;
                                 break;
                         }
@@ -499,7 +499,7 @@ namespace MGS2_MC
             itemGuiObjectList.Add(new GuiObject("Infinity Wig", infinityWigGroupBox));
             itemGuiObjectList.Add(new GuiObject("MO Disc", moDiscGroupBox));
             itemGuiObjectList.Add(new GuiObject("Mine Detector", mineDetectorGroupBox));
-            itemGuiObjectList.Add(new GuiObject("Night Vision Goggles", nvgGroupBox));
+            itemGuiObjectList.Add(new GuiObject("NVGs", nvgGroupBox));
             itemGuiObjectList.Add(new GuiObject("Orange Wig", orangeWigGroupBox));
             itemGuiObjectList.Add(new GuiObject("Pentazemin", pentazeminGroupBox));
             itemGuiObjectList.Add(new GuiObject("Phone", phoneGroupBox));
@@ -509,10 +509,10 @@ namespace MGS2_MC
             itemGuiObjectList.Add(new GuiObject("Sensor A", sensorAGroupBox));
             itemGuiObjectList.Add(new GuiObject("Sensor B", sensorBGroupBox));
             itemGuiObjectList.Add(new GuiObject("Shaver", shaverGroupBox));
-            itemGuiObjectList.Add(new GuiObject("Socom Suppressor", socomGroupBox));
+            itemGuiObjectList.Add(new GuiObject("SOCOM Supp", socomSupGroupBox));
             itemGuiObjectList.Add(new GuiObject("Stealth", stealthGroupBox));
             itemGuiObjectList.Add(new GuiObject("Thermal Goggles", thermalGroupBox));
-            itemGuiObjectList.Add(new GuiObject("USP Suppressor", uspSupGroupBox));
+            itemGuiObjectList.Add(new GuiObject("USP Supp", uspSupGroupBox));
             itemGuiObjectList.Add(new GuiObject("Wet Box", wetBoxGroupBox));
 
             weaponGuiObjectList.Add(new GuiObject("AKS-74u", akGroupBox));
@@ -1404,7 +1404,7 @@ namespace MGS2_MC
             catch(Exception ex)
             {
                 _logger.Error($"Failed to update game string: {ex}");
-                MessageBox.Show($"Failed to update game string");
+                MessageBox.Show($@"Failed to update game string");
             }
         }
 
@@ -1478,7 +1478,7 @@ namespace MGS2_MC
         {
             if (Program.MGS2Thread.IsAlive)
             {
-                MessageBox.Show("MGS2 is already running, please exit MGS2 before attempting to launch it again.");
+                MessageBox.Show(@"MGS2 is already running, please exit MGS2 before attempting to launch it again.");
             }
             else
             {

--- a/MGS2-MC/MGS2 MC Cheat Trainer(WindowsOnly).csproj
+++ b/MGS2-MC/MGS2 MC Cheat Trainer(WindowsOnly).csproj
@@ -40,7 +40,7 @@
     <BootstrapperEnabled>true</BootstrapperEnabled>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>x64</PlatformTarget>
+    <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
@@ -66,7 +66,7 @@
     <PlatformTarget>x64</PlatformTarget>
     <LangVersion>7.3</LangVersion>
     <ErrorReport>prompt</ErrorReport>
-    <Prefer32Bit>false</Prefer32Bit>
+    <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <OutputPath>bin\x64\Release\</OutputPath>
@@ -86,7 +86,7 @@
     <PlatformTarget>x86</PlatformTarget>
     <LangVersion>7.3</LangVersion>
     <ErrorReport>prompt</ErrorReport>
-    <Prefer32Bit>false</Prefer32Bit>
+    <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
     <OutputPath>bin\x86\Release\</OutputPath>

--- a/MGS2-MC/MGS2 MC Cheat Trainer(WindowsOnly).csproj
+++ b/MGS2-MC/MGS2 MC Cheat Trainer(WindowsOnly).csproj
@@ -40,7 +40,7 @@
     <BootstrapperEnabled>true</BootstrapperEnabled>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
+    <PlatformTarget>x64</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
@@ -66,7 +66,7 @@
     <PlatformTarget>x64</PlatformTarget>
     <LangVersion>7.3</LangVersion>
     <ErrorReport>prompt</ErrorReport>
-    <Prefer32Bit>true</Prefer32Bit>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <OutputPath>bin\x64\Release\</OutputPath>
@@ -86,7 +86,7 @@
     <PlatformTarget>x86</PlatformTarget>
     <LangVersion>7.3</LangVersion>
     <ErrorReport>prompt</ErrorReport>
-    <Prefer32Bit>true</Prefer32Bit>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
     <OutputPath>bin\x86\Release\</OutputPath>

--- a/MGS2-MC/MGS2MemoryManager.cs
+++ b/MGS2-MC/MGS2MemoryManager.cs
@@ -1,6 +1,7 @@
 ﻿using Serilog;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -10,6 +11,7 @@ namespace MGS2_MC
 {
     internal static class MGS2MemoryManager
     {
+        private static int counter = 0;
         #region Internals
         private const string loggerName = "MemoryManagerDebuglog.log";
 
@@ -220,9 +222,28 @@ namespace MGS2_MC
                 throw new AggregateException($"Failed to find player offset: ", e);
             }
         }
+        
+        private static Process GetMgs2Process()
+        {
+            Process[] processes = Process.GetProcesses();
+            foreach (Process p in processes)
+            {
+                if(p.ProcessName.ToLower() == "metal gear solid2")
+                    return Process.GetProcessById(p.Id);
+            }
+            return new Process();
+        }
 
         private static int[] GetPlayerOffsets()
         {
+            /*
+             * For some reason, MGS2Monitor is not retrieving the correct MGS2 Process
+             * and it's not throwing any errors either. I had to hard code the Process
+             * to MGS2Monitor.MGS2Process and it works, at least on my machine fine
+             */
+            if (counter++ == 0)
+                MGS2Monitor.MGS2Process = GetMgs2Process();
+            
             using (SimpleProcessProxy proxy = new SimpleProcessProxy(MGS2Monitor.MGS2Process))
             {
                 byte[] gameMemoryBuffer = proxy.GetProcessSnapshot();

--- a/MGS2-MC/MGS2MemoryManager.cs
+++ b/MGS2-MC/MGS2MemoryManager.cs
@@ -228,7 +228,7 @@ namespace MGS2_MC
             Process[] processes = Process.GetProcesses();
             foreach (Process p in processes)
             {
-                if(p.ProcessName.ToLower() == "metal gear solid2")
+                if(string.Equals(p.ProcessName, Constants.MGS2_PROCESS_NAME, StringComparison.CurrentCultureIgnoreCase))
                     return Process.GetProcessById(p.Id);
             }
             return new Process();


### PR DESCRIPTION
For some reason, MGS2Monitor.MGS2Process wasn't null but it wasn't the right process either. I hard coded one check to get the correct process during the GetPlayerOffsets() method first call. I haven't ran into any issues.